### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/include/multipath/complex.rb
+++ b/src/include/multipath/complex.rb
@@ -2248,7 +2248,7 @@ module Yast
               else
                 match = false
               end
-              match ? new_item : item
+              match ? deep_copy(new_item) : deep_copy(item)
             end
             break
           end
@@ -2918,7 +2918,7 @@ module Yast
               else
                 match = false
               end
-              match ? new_item : item
+              match ? deep_copy(new_item) : deep_copy(item)
             end
             break
           end


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
