### PR TITLE
bsc#1117592, use random file name. Version 4.1.1

### DIFF
--- a/package/yast2-multipath.changes
+++ b/package/yast2-multipath.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 30 09:23:19 UTC 2018 - nwang@suse.com
+
+- CVE-2018-17955, use random file name (bsc#1117592)
+- 4.1.1
+
+-------------------------------------------------------------------
 Sun Nov 25 18:30:26 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-multipath.spec
+++ b/package/yast2-multipath.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-multipath
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/multipath/complex.rb
+++ b/src/include/multipath/complex.rb
@@ -29,6 +29,7 @@
 
 require "yast"
 require "y2storage"
+require "securerandom"
 
 module Yast
   module MultipathComplexInclude
@@ -49,7 +50,9 @@ module Yast
       @service_status = 0
       @has_dumbtab = false
       @device_template = "vendor %1; product %2"
-      @builtin_multipath_conf_path = "/tmp/.yast2-multipath-builtin-conf"
+
+      r = SecureRandom.hex
+      @builtin_multipath_conf_path = "/tmp/.yast2-multipath-builtin-conf-" + r[0,8]
 
       Yast.include include_target, "multipath/options.rb"
 


### PR DESCRIPTION
Use random file name for temporary file. (CVE-2018-17955)
Use Cheetah to replace the .target.bash of /sbin/multipath -t >/tmp/.XXX 